### PR TITLE
Remove Orchard Core Preview Feed

### DIFF
--- a/Content/README.md
+++ b/Content/README.md
@@ -8,6 +8,10 @@ Orchard Core Site Boilerplate Description
 
 Orchard Core runs on the .NET Core. Download the latest version from [https://www.microsoft.com/net/download/core](https://www.microsoft.com/net/download/core).
 
+## Orchard Core Reference
+
+This module is referencing the beta 3 build of Orchard Core ([`1.0.0-beta3-71077`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-beta3-71077)).
+
 ## Running Locally
 
 ### CLI

--- a/Content/nuget.config
+++ b/Content/nuget.config
@@ -3,7 +3,6 @@
 	<packageSources>
 		<clear />
 		<add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-		<add key="Orchard Core Preview" value="https://www.myget.org/F/orchardcore-preview/api/v3/index.json" />
 	</packageSources>
 	<activePackageSource>
 		<add key="All" value="(Aggregate source)" />

--- a/Etch.OrchardCore.SiteBoilerplate.nuspec
+++ b/Etch.OrchardCore.SiteBoilerplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Etch.OrchardCore.SiteBoilerplate</id>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <title>Etch Orchard Core Site Boilerplate</title>
     <description>
       Boilerplate site that is our starting point for building OrchardCore sites.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Site boilerplate is our starting point for building Orchard Core sites.
 
 ## Build Status
 
-[![Build Status](https://secure.travis-ci.org/etchuk/Etch.OrchardCore.SiteBoilerplate.png?branch=master)](http://travis-ci.org/etchuk/Etch.OrchardCore.SiteBoilerplate) [![NuGet](https://img.shields.io/nuget/v/Etch.OrchardCore.SiteBoilerplate.svg)](https://www.nuget.org/packages/Etch.OrchardCore.SiteBoilerplate)
+[![Build Status](https://secure.travis-ci.org/EtchUK/Etch.OrchardCore.SiteBoilerplate.png?branch=master)](http://travis-ci.org/EtchUK/Etch.OrchardCore.SiteBoilerplate) [![NuGet](https://img.shields.io/nuget/v/Etch.OrchardCore.SiteBoilerplate.svg)](https://www.nuget.org/packages/Etch.OrchardCore.SiteBoilerplate)
 
 ### Getting Started
 


### PR DESCRIPTION
Removed the preview feed so projects target the stable version of Orchard Core by default.