### PR TITLE
Add appsettings.json with media supported sizes configuration

### DIFF
--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/appsettings.json
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/appsettings.json
@@ -1,0 +1,8 @@
+{
+    "OrchardCore": {
+      "OrchardCore.Media": {
+        "SupportedSizes": [375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560]
+      }
+    }
+  }
+  


### PR DESCRIPTION
Majority of projects will need the ability to configure via `appsettings.json`. Included configuration for supported sizes for resizing media within the `OrchardCore.Media` module. The sizes are our common breakpoints for background images within a hero component.

Fixes #19