### PR TITLE
Add 240 to OrchardCore.Media.SupportedSizes

### DIFF
--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/appsettings.json
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/appsettings.json
@@ -1,8 +1,7 @@
 {
-    "OrchardCore": {
-      "OrchardCore.Media": {
-        "SupportedSizes": [375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560]
-      }
+  "OrchardCore": {
+    "OrchardCore.Media": {
+      "SupportedSizes": [ 240, 375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560 ]
     }
   }
-  
+}


### PR DESCRIPTION
Add 240px to OrchardCore.Media.SupportedSizes to stop media library thumbnail images rendering at full size.

This should fix #22