### PR TITLE
Upgrade to Orchard Core RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: csharp
 mono: none
 dist: xenial
-dotnet: 2.2
+dotnet: 3.0
 
 env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    - DOTNET_CLI_TELEMETRY_OPTOUT: 1   
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
     - WORKING_DIR=Content
-  
+
 install:
- - cd $WORKING_DIR
- - dotnet restore
+  - cd $WORKING_DIR
+  - dotnet restore
 
 script:
- - dotnet build
+  - dotnet build

--- a/Content/.gitignore
+++ b/Content/.gitignore
@@ -344,3 +344,4 @@ ASALocalRun/
 healthchecksdb
 
 App_Data/
+Localization

--- a/Content/Etch.OrchardCore.SiteBoilerplate.sln
+++ b/Content/Etch.OrchardCore.SiteBoilerplate.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.168
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29324.140
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Etch.OrchardCore.SiteBoilerplate", "src\Etch.OrchardCore.SiteBoilerplate\Etch.OrchardCore.SiteBoilerplate.csproj", "{4EAEB124-E0A2-495A-914B-9529008E6AAA}"
 EndProject

--- a/Content/README.md
+++ b/Content/README.md
@@ -10,7 +10,7 @@ Orchard Core runs on the .NET Core. Download the latest version from [https://ww
 
 ## Orchard Core Reference
 
-This module is referencing the beta 3 build of Orchard Core ([`1.0.0-beta3-71077`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-beta3-71077)).
+This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
 
 ## Running Locally
 

--- a/Content/azure-pipeline.yml
+++ b/Content/azure-pipeline.yml
@@ -2,7 +2,7 @@ trigger:
   - master
   
 pool:
-  vmImage: "vs2017-win2016"
+  vmImage: "windows-2019"
 
 variables:
   buildConfiguration: "Release"

--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <PreserveCompilationReferences>true</PreserveCompilationReferences>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,17 +12,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Etch.OrchardCore.ContextualEdit" Version="0.1.0-beta" />
-    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.6.1-beta" />
-    <PackageReference Include="Etch.OrchardCore.Gallery" Version="0.1.1-beta" />
-    <PackageReference Include="Etch.OrchardCore.InjectScripts" Version="0.1.0-beta" />
-    <PackageReference Include="Etch.OrchardCore.Search" Version="0.0.1-beta" />
-    <PackageReference Include="Etch.OrchardCore.SEO" Version="0.4.4-beta" />
-    <PackageReference Include="Etch.OrchardCore.Widgets" Version="0.5.2-beta" />
-    <PackageReference Include="Etch.OrchardCore.Workflows" Version="0.1.0-beta" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Logging.NLog" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="Etch.OrchardCore.ContextualEdit" Version="0.2.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.7.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.Gallery" Version="0.2.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.InjectScripts" Version="0.2.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.SEO" Version="0.5.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.Widgets" Version="0.6.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.Workflows" Version="0.2.0-rc1" />
+    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Logging.NLog" Version="1.0.0-rc1-10004" />
   </ItemGroup>
 
 </Project>

--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/Startup.cs
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/Startup.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Etch.OrchardCore.SiteBoilerplate
 {
@@ -15,7 +15,7 @@ namespace Etch.OrchardCore.SiteBoilerplate
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/Etch.OrchardCore.SiteBoilerplate.nuspec
+++ b/Etch.OrchardCore.SiteBoilerplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Etch.OrchardCore.SiteBoilerplate</id>
-    <version>0.3.3</version>
+    <version>0.4.0</version>
     <title>Etch Orchard Core Site Boilerplate</title>
     <description>
       Boilerplate site that is our starting point for building OrchardCore sites.

--- a/azure-pipeline-stable.yml
+++ b/azure-pipeline-stable.yml
@@ -1,0 +1,15 @@
+pool:
+  vmImage: 'windows-2019'
+
+steps:
+- task: NuGetCommand@2
+  displayName: 'NuGet pack'
+  inputs:
+    command: pack
+    packagesToPack: Etch.OrchardCore.SiteBoilerplate.nuspec
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Pipeline Artifact'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)'
+    artifact: drop


### PR DESCRIPTION
- Change target framework to .NET core 3.0
- Update all Orchard Core dependencies to point to rc1 release
- Update Etch packages to RC1 version
- Removed `Etch.OrchardCore.Search` (not yet been migrated)
- Add `Localization` to gitignore
- Change project `Startup` to use `IWebHostEnvironment`
- Update build files to target .NET core 3.0
- Add build file for build template
- Update version number