### PR TITLE
Remove sample Orchard Core themes

### DIFF
--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Etch.OrchardCore.SEO" Version="0.5.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.Widgets" Version="0.6.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.Workflows" Version="0.2.0-rc1" />
-    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Application.Cms.Core.Targets" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.Logging.NLog" Version="1.0.0-rc1-10004" />
   </ItemGroup>
 


### PR DESCRIPTION
Orchard Core now includes a new package that doesn't include the sample themes (e.g. ComingSoonTheme).

https://github.com/OrchardCMS/OrchardCore/issues/3984.

This does mean that our projects will need to define a custom SaaS recipe (or "Host" as we refer it as). However, the plan is to have a host theme anyways, which will take care of that.