### PR TITLE
Terraform: support Elastic Pool and improve defaults for database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,9 +340,4 @@ ASALocalRun/
 # BeatPulse healthcheck temp database
 healthchecksdb
 
-# Terraform
-*.tfstate*
-.terraform
-*.tfvars
-
 App_Data/

--- a/Content/deployment/terraform/.gitignore
+++ b/Content/deployment/terraform/.gitignore
@@ -1,5 +1,11 @@
-# Ignore plan files
+# Terraform hidden directory
+.terraform
+
+# Plan files
 *.ter
 
-# Ignore var files for local testing, variables shouldn't be committed to repos
+# Var files for local testing, variables shouldn't be committed to repos
 *.tfvars
+
+# State files
+*.tfstate*

--- a/Content/deployment/terraform/azure/README.md
+++ b/Content/deployment/terraform/azure/README.md
@@ -30,6 +30,7 @@ The site configuration itself is implemented as a module under the `resources` d
 * `RG_NAME` - Name of resource group to deploy into, must already exist
 * `RG_NAME_ALT` - Optional name of 'major' region resource group in case `RG_NAME` doesn't support certain resources like CDN
 * `SP_NAME` - Name of service plan to deploy into, must already exist
+* `SQL_ELASTIC_POOL` - Optional name of SQL Elastic Pool to assign the database too, must already exist
 * `SQL_SERVER_NAME` - Name of SQL Server to deploy into, must already exist
 
 A note on `ENV` and `PROJECT`, these will be used together to create names for resources, invalid characters will be removed and spaces will be replaced with `-`.

--- a/Content/deployment/terraform/azure/main.tf
+++ b/Content/deployment/terraform/azure/main.tf
@@ -19,5 +19,6 @@ module "resources" {
   rg_name            = "${var.RG_NAME}"
   rg_name_alt        = "${var.RG_NAME_ALT}"
   sp_name            = "${var.SP_NAME}"
+  sql_elastic_pool   = "${var.SQL_ELASTIC_POOL}"
   sql_server_name    = "${var.SQL_SERVER_NAME}"
 }

--- a/Content/deployment/terraform/azure/resources/main.tf
+++ b/Content/deployment/terraform/azure/resources/main.tf
@@ -78,6 +78,9 @@ resource "azurerm_sql_database" "sd" {
   resource_group_name = "${data.azurerm_resource_group.rg.name}"
   location            = "${data.azurerm_resource_group.rg.location}"
   server_name         = "${var.sql_server_name}"
+
+  edition                          = "Standard"
+  requested_service_objective_name = "S0"
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "hostnames" {

--- a/Content/deployment/terraform/azure/resources/main.tf
+++ b/Content/deployment/terraform/azure/resources/main.tf
@@ -80,7 +80,8 @@ resource "azurerm_sql_database" "sd" {
   server_name         = "${var.sql_server_name}"
 
   edition                          = "Standard"
-  requested_service_objective_name = "S0"
+  requested_service_objective_name = "${var.sql_elastic_pool != "" ? "ElasticPool" : "S0"}"
+  elastic_pool_name                = "${var.sql_elastic_pool}"
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "hostnames" {

--- a/Content/deployment/terraform/azure/resources/variables.tf
+++ b/Content/deployment/terraform/azure/resources/variables.tf
@@ -4,8 +4,8 @@ variable "env" {
 
 variable "hostnames" {
   description = "Hostnames to bind to the app service"
-  type    = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "le_client_id" {
@@ -26,9 +26,8 @@ variable "le_tenant" {
 
 variable "project" {
   description = "Project name for resource names"
-  default = "Orchard Core Site Boilerplate"
+  default     = "Orchard Core Site Boilerplate"
 }
-
 
 variable "rg_name" {
   description = "Name of resource group to create infrastructure in"
@@ -41,6 +40,10 @@ variable "rg_name_alt" {
 
 variable "sp_name" {
   description = "Name of service plan to create app service in"
+}
+
+variable "sql_elastic_pool" {
+  description = "Elastic pool to assign SQL database to"
 }
 
 variable "sql_server_name" {

--- a/Content/deployment/terraform/azure/variables.tf
+++ b/Content/deployment/terraform/azure/variables.tf
@@ -42,6 +42,10 @@ variable "SP_NAME" {
   description = "Name of service plan to create app service in"
 }
 
+variable "SQL_ELASTIC_POOL" {
+  description = "Name of Elastic Pool to create database in"
+}
+
 variable "SQL_SERVER_NAME" {
   description = "Name of SQL server to create database in"
 }

--- a/Etch.OrchardCore.SiteBoilerplate.nuspec
+++ b/Etch.OrchardCore.SiteBoilerplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Etch.OrchardCore.SiteBoilerplate</id>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <title>Etch Orchard Core Site Boilerplate</title>
     <description>
       Boilerplate site that is our starting point for building OrchardCore sites.


### PR DESCRIPTION
Updates the Terraform script for Azure so that the default database size is Standard:S0 instead of a massive VCore based instance.

Adds support for assigning the database to an Elastic Pool through a new Terraform variable.

Fixes #31 