### PR TITLE
Add custom admin theme

### DIFF
--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Etch.OrchardCore.AdminTheme" Version="0.1.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.Blocks" Version="0.1.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.ContextualEdit" Version="0.2.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.DefaultTheme" Version="0.5.1-rc1" />


### PR DESCRIPTION
We've added a custom admin theme that aids us to address issues between new releases of Orchard Core. The admin theme can be found at the repository linked below.

https://github.com/EtchUK/Etch.OrchardCore.AdminTheme