### PR TITLE
v0.4.5

### DIFF
--- a/Content/azure-pipeline.yml
+++ b/Content/azure-pipeline.yml
@@ -1,3 +1,6 @@
+resources:
+  - repo: self
+
 trigger:
   - master
   
@@ -8,18 +11,47 @@ variables:
   buildConfiguration: "Release"
 
 steps:
-  - script: dotnet build --configuration $(buildConfiguration)
-    displayName: "Building"
-  - script: dotnet publish --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)
-    displayName: "Packaging"
-  - task: ArchiveFiles@2
-    displayName: "Archiving"
+  - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+    displayName: "Restore artifact based on: **/package-lock.json"
     inputs:
-      rootFolderOrFile: "$(Build.ArtifactStagingDirectory)"
-      includeRootFolder: false
-      archiveFile: "$(Build.ArtifactStagingDirectory)/package/build-$(Build.BuildId).zip"
-      archiveType: "zip"
+      keyfile: "**/package-lock.json"
+      targetfolder: "**/node_modules,**/node_modules/**/node_modules"
+      vstsFeed: "43c91cfb-ae45-4e8c-a2f5-8a34df9e3b8a"
+
+  - task: UseNode@1
+    inputs:
+      version: '8.x'
+      checkLatest: true
+
+  - task: DotNetCoreCLI@2
+    displayName: "dotnet build"
+    inputs:
+      command: build
+      arguments: "--configuration $(buildConfiguration)"
+
+  - task: DotNetCoreCLI@2
+    displayName: "dotnet publish"
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '.\src\Etch.OrchardCore.SiteBoilerplate\Etch.OrchardCore.SiteBoilerplate.csproj'
+      arguments: "--configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)"
+
+  - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
+    displayName: "Save artifact based on: **/package-lock.json"
+    inputs:
+      keyfile: "**/package-lock.json"
+      targetfolder: "**/node_modules,**/node_modules/**/node_modules"
+      vstsFeed: "43c91cfb-ae45-4e8c-a2f5-8a34df9e3b8a"
+
+  - task: CopyFiles@2
+    displayName: "Copy Terraform scripts"
+    inputs:
+      SourceFolder: deployment/terraform/azure
+      Contents: "**/*.tf"
+      TargetFolder: "$(Build.ArtifactStagingDirectory)/terraform"
+
   - task: PublishBuildArtifacts@1
     displayName: "Publishing"
     inputs:
-      pathtoPublish: "$(Build.ArtifactStagingDirectory)/package"
+      pathtoPublish: "$(Build.ArtifactStagingDirectory)"

--- a/Content/deployment/terraform/azure/main.tf
+++ b/Content/deployment/terraform/azure/main.tf
@@ -1,5 +1,6 @@
 provider "azurerm" {
-  version = "~> 1.25"
+  version = "=2.0.0"
+  features {}
 }
 
 terraform {

--- a/Content/deployment/terraform/azure/resources/main.tf
+++ b/Content/deployment/terraform/azure/resources/main.tf
@@ -1,19 +1,27 @@
 data "azurerm_resource_group" "rg" {
-  name = "${var.rg_name}"
+  name = var.rg_name
 }
 
 data "azurerm_resource_group" "rg_alt" {
-  name = "${var.rg_name_alt != "" ? var.rg_name_alt : var.rg_name}"
+  name = var.rg_name_alt != "" ? var.rg_name_alt : var.rg_name
 }
 
 data "azurerm_app_service_plan" "sp" {
-  name                = "${var.sp_name}"
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
+  name                = var.sp_name
+  resource_group_name = data.azurerm_resource_group.rg.name
 }
 
 locals {
-  project_basic_name      = "${lower(replace(format("%s%s", var.env, var.project), "/[^A-Za-z]+/", ""))}"
-  project_hyphenated_name = "${lower(replace(replace(format("%s-%s", var.project, var.env), " ", "-"), "/[^A-Za-z\\-]+/", ""))}"
+  project_basic_name = lower(
+    replace(format("%s%s", var.env, var.project), "/[^A-Za-z]+/", ""),
+  )
+  project_hyphenated_name = lower(
+    replace(
+      replace(format("%s-%s", var.project, var.env), " ", "-"),
+      "/[^A-Za-z\\-]+/",
+      "",
+    ),
+  )
 }
 
 resource "random_id" "cdn" {
@@ -25,44 +33,45 @@ resource "random_id" "cdn" {
 }
 
 resource "azurerm_app_service" "as" {
-  name                = "${local.project_hyphenated_name}"
-  location            = "${data.azurerm_resource_group.rg.location}"
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  app_service_plan_id = "${data.azurerm_app_service_plan.sp.id}"
+  name                = local.project_hyphenated_name
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+  app_service_plan_id = data.azurerm_app_service_plan.sp.id
   https_only          = true
 
   app_settings = {
-    "AzureWebJobsDashboard" = "${azurerm_storage_account.sa.primary_connection_string}"
-    "AzureWebJobsStorage"   = "${azurerm_storage_account.sa.primary_connection_string}"
-    "DashboardConnectionString" = "${azurerm_storage_account.sa.primary_connection_string}"
-    "StorageConnectionString"   = "${azurerm_storage_account.sa.primary_connection_string}"
-
-    "letsencrypt:ClientId"                     = "${var.le_client_id}"
-    "letsencrypt:ClientSecret"                 = "${var.le_client_secret}"
-    "letsencrypt:ResourceGroupName"            = "${data.azurerm_resource_group.rg.name}"
-    "letsencrypt:ServicePlanResourceGroupName" = "${data.azurerm_resource_group.rg.name}"
-    "letsencrypt:SiteSlot"                     = ""
-    "letsencrypt:SubscriptionId"               = "${var.le_subscription_id}"
-    "letsencrypt:Tenant"                       = "${var.le_tenant}"
-    "letsencrypt:UseIPBasedSSL"                = "false"
-
-    "OrchardCore:OrchardCore.Media.Azure:ConnectionString" = "${azurerm_storage_account.sa.primary_connection_string}"
+    "AzureWebJobsDashboard"                                = azurerm_storage_account.sa.primary_connection_string
+    "AzureWebJobsStorage"                                  = azurerm_storage_account.sa.primary_connection_string
+    "DashboardConnectionString"                            = azurerm_storage_account.sa.primary_connection_string
+    "StorageConnectionString"                              = azurerm_storage_account.sa.primary_connection_string
+    "letsencrypt:ClientId"                                 = var.le_client_id
+    "letsencrypt:ClientSecret"                             = var.le_client_secret
+    "letsencrypt:ResourceGroupName"                        = data.azurerm_resource_group.rg.name
+    "letsencrypt:ServicePlanResourceGroupName"             = data.azurerm_resource_group.rg.name
+    "letsencrypt:SiteSlot"                                 = ""
+    "letsencrypt:SubscriptionId"                           = var.le_subscription_id
+    "letsencrypt:Tenant"                                   = var.le_tenant
+    "letsencrypt:UseIPBasedSSL"                            = "false"
+    "OrchardCore:OrchardCore.Media.Azure:ConnectionString" = azurerm_storage_account.sa.primary_connection_string
     "OrchardCore:OrchardCore.Media.Azure:ContainerName"    = "media"
     "OrchardCore:OrchardCore.Media.Azure:PublicHostName"   = "${random_id.cdn.hex}.azureedge.net"
-
-    "WEBSITE_NODE_DEFAULT_VERSION" = "6.9.1"
-    "WEBSITE_RUN_FROM_PACKAGE"     = "0"
+    "WEBSITE_NODE_DEFAULT_VERSION"                         = "6.9.1"
+    "WEBSITE_RUN_FROM_PACKAGE"                             = "0"
   }
 
-  site_config = {
+  site_config {
     always_on = true
   }
 }
 
 resource "azurerm_storage_account" "sa" {
-  name                     = "${substr(local.project_basic_name, 0, min(24, length(local.project_basic_name)))}"
-  resource_group_name      = "${data.azurerm_resource_group.rg.name}"
-  location                 = "${data.azurerm_resource_group.rg.location}"
+  name = substr(
+    local.project_basic_name,
+    0,
+    min(24, length(local.project_basic_name)),
+  )
+  resource_group_name      = data.azurerm_resource_group.rg.name
+  location                 = data.azurerm_resource_group.rg.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
   account_kind             = "StorageV2"
@@ -70,27 +79,26 @@ resource "azurerm_storage_account" "sa" {
 
 resource "azurerm_storage_container" "sac" {
   name                  = "media"
-  resource_group_name   = "${data.azurerm_resource_group.rg.name}"
-  storage_account_name  = "${azurerm_storage_account.sa.name}"
+  storage_account_name  = azurerm_storage_account.sa.name
   container_access_type = "container"
 }
 
 resource "azurerm_sql_database" "sd" {
-  name                = "${local.project_hyphenated_name}"
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  location            = "${data.azurerm_resource_group.rg.location}"
-  server_name         = "${var.sql_server_name}"
+  name                = local.project_hyphenated_name
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.rg.location
+  server_name         = var.sql_server_name
 
   edition                          = "Standard"
-  requested_service_objective_name = "${var.sql_elastic_pool != "" ? "ElasticPool" : "S0"}"
-  elastic_pool_name                = "${var.sql_elastic_pool}"
+  requested_service_objective_name = var.sql_elastic_pool != "" ? "ElasticPool" : "S0"
+  elastic_pool_name                = var.sql_elastic_pool
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "hostnames" {
-  count               = "${length(var.hostnames)}"
-  hostname            = "${var.hostnames[count.index]}"
-  app_service_name    = "${azurerm_app_service.as.name}"
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
+  count               = length(var.hostnames)
+  hostname            = var.hostnames[count.index]
+  app_service_name    = azurerm_app_service.as.name
+  resource_group_name = data.azurerm_resource_group.rg.name
 
   lifecycle {
     ignore_changes = [
@@ -101,21 +109,22 @@ resource "azurerm_app_service_custom_hostname_binding" "hostnames" {
 }
 
 resource "azurerm_cdn_profile" "cp" {
-  name                = "${local.project_hyphenated_name}"
-  location            = "${data.azurerm_resource_group.rg_alt.location}"
-  resource_group_name = "${data.azurerm_resource_group.rg_alt.name}"
+  name                = local.project_hyphenated_name
+  location            = data.azurerm_resource_group.rg_alt.location
+  resource_group_name = data.azurerm_resource_group.rg_alt.name
   sku                 = "Standard_Verizon"
 }
 
 resource "azurerm_cdn_endpoint" "ce" {
-  name                = "${random_id.cdn.hex}"
-  profile_name        = "${azurerm_cdn_profile.cp.name}"
-  location            = "${data.azurerm_resource_group.rg_alt.location}"
-  resource_group_name = "${data.azurerm_resource_group.rg_alt.name}"
-  origin_host_header  = "${azurerm_storage_account.sa.primary_blob_host}"
+  name                = random_id.cdn.hex
+  profile_name        = azurerm_cdn_profile.cp.name
+  location            = data.azurerm_resource_group.rg_alt.location
+  resource_group_name = data.azurerm_resource_group.rg_alt.name
+  origin_host_header  = azurerm_storage_account.sa.primary_blob_host
 
-  origin = {
+  origin {
     name      = "StorageAccount"
-    host_name = "${azurerm_storage_account.sa.primary_blob_host}"
+    host_name = azurerm_storage_account.sa.primary_blob_host
   }
 }
+

--- a/Content/deployment/terraform/azure/resources/main.tf
+++ b/Content/deployment/terraform/azure/resources/main.tf
@@ -54,7 +54,7 @@ resource "azurerm_app_service" "as" {
     "letsencrypt:UseIPBasedSSL"                            = "false"
     "OrchardCore:OrchardCore.Media.Azure:ConnectionString" = azurerm_storage_account.sa.primary_connection_string
     "OrchardCore:OrchardCore.Media.Azure:ContainerName"    = "media"
-    "OrchardCore:OrchardCore.Media.Azure:PublicHostName"   = "${random_id.cdn.hex}.azureedge.net"
+    "OrchardCore:OrchardCore.Media:CdnBaseUrl"             = "${random_id.cdn.hex}.azureedge.net"
     "WEBSITE_NODE_DEFAULT_VERSION"                         = "6.9.1"
     "WEBSITE_RUN_FROM_PACKAGE"                             = "0"
   }

--- a/Content/deployment/terraform/azure/resources/outputs.tf
+++ b/Content/deployment/terraform/azure/resources/outputs.tf
@@ -1,3 +1,4 @@
 output "app_service_name" {
-    value = "${azurerm_app_service.as.name}"
+  value = azurerm_app_service.as.name
 }
+

--- a/Content/deployment/terraform/azure/resources/variables.tf
+++ b/Content/deployment/terraform/azure/resources/variables.tf
@@ -4,7 +4,7 @@ variable "env" {
 
 variable "hostnames" {
   description = "Hostnames to bind to the app service"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
@@ -49,3 +49,4 @@ variable "sql_elastic_pool" {
 variable "sql_server_name" {
   description = "Name of SQL server to create database in"
 }
+

--- a/Content/deployment/terraform/azure/resources/versions.tf
+++ b/Content/deployment/terraform/azure/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/Content/deployment/terraform/azure/variables.tf
+++ b/Content/deployment/terraform/azure/variables.tf
@@ -1,52 +1,52 @@
-variable "env" {
+variable "ENV" {
   description = "Environment descriptor"
 }
 
-variable "hostnames" {
+variable "HOSTNAMES" {
   description = "Hostnames to bind to the app service"
   type        = list(string)
   default     = []
 }
 
-variable "le_client_id" {
+variable "LE_CLIENT_ID" {
   description = "Lets Encrypt APP ID"
 }
 
-variable "le_client_secret" {
+variable "LE_CLIENT_SECRET" {
   description = "Lets Encrypt App ID"
 }
 
-variable "le_subscription_id" {
+variable "LE_SUBSCRIPTION_ID" {
   description = "Lets Encrypt Subscription ID"
 }
 
-variable "le_tenant" {
+variable "LE_TENANT" {
   description = "Lets Encrypt Tenant"
 }
 
-variable "project" {
+variable "PROJECT" {
   description = "Project name for resource names"
-  default     = "Orchard Core Site Boilerplate"
+  default     = "Play CMS Demo"
 }
 
-variable "rg_name" {
+variable "RG_NAME" {
   description = "Name of resource group to create infrastructure in"
 }
 
-variable "rg_name_alt" {
+variable "RG_NAME_ALT" {
   description = "Name of alternative resource group to create infrastructure in, used for items like CDN which can only be created in 'major' regions"
   default     = ""
 }
 
-variable "sp_name" {
+variable "SP_NAME" {
   description = "Name of service plan to create app service in"
 }
 
-variable "sql_elastic_pool" {
+variable "SQL_ELASTIC_POOL" {
   description = "Elastic pool to assign SQL database to"
 }
 
-variable "sql_server_name" {
+variable "SQL_SERVER_NAME" {
   description = "Name of SQL server to create database in"
 }
 

--- a/Content/deployment/terraform/azure/variables.tf
+++ b/Content/deployment/terraform/azure/variables.tf
@@ -1,51 +1,52 @@
-variable "ENV" {
+variable "env" {
   description = "Environment descriptor"
 }
 
-variable "HOSTNAMES" {
+variable "hostnames" {
   description = "Hostnames to bind to the app service"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
-variable "LE_CLIENT_ID" {
+variable "le_client_id" {
   description = "Lets Encrypt APP ID"
 }
 
-variable "LE_CLIENT_SECRET" {
+variable "le_client_secret" {
   description = "Lets Encrypt App ID"
 }
 
-variable "LE_SUBSCRIPTION_ID" {
+variable "le_subscription_id" {
   description = "Lets Encrypt Subscription ID"
 }
 
-variable "LE_TENANT" {
+variable "le_tenant" {
   description = "Lets Encrypt Tenant"
 }
 
-variable "PROJECT" {
-  description = "Project name for use in resource names"
+variable "project" {
+  description = "Project name for resource names"
   default     = "Orchard Core Site Boilerplate"
 }
 
-variable "RG_NAME" {
+variable "rg_name" {
   description = "Name of resource group to create infrastructure in"
 }
 
-variable "RG_NAME_ALT" {
+variable "rg_name_alt" {
   description = "Name of alternative resource group to create infrastructure in, used for items like CDN which can only be created in 'major' regions"
   default     = ""
 }
 
-variable "SP_NAME" {
+variable "sp_name" {
   description = "Name of service plan to create app service in"
 }
 
-variable "SQL_ELASTIC_POOL" {
-  description = "Name of Elastic Pool to create database in"
+variable "sql_elastic_pool" {
+  description = "Elastic pool to assign SQL database to"
 }
 
-variable "SQL_SERVER_NAME" {
+variable "sql_server_name" {
   description = "Name of SQL server to create database in"
 }
+

--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
@@ -12,18 +12,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Etch.OrchardCore.AdminTheme" Version="0.1.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Blocks" Version="0.1.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.ContentPermissions" Version="0.1.2-rc1" />
+    <PackageReference Include="Etch.OrchardCore.AdminTheme" Version="0.2.1-rc1" />
+    <PackageReference Include="Etch.OrchardCore.Blocks" Version="0.2.1-rc1" />
+    <PackageReference Include="Etch.OrchardCore.ContentPermissions" Version="0.2.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.ContextualEdit" Version="0.2.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.DefaultTheme" Version="0.5.1-rc1" />
     <PackageReference Include="Etch.OrchardCore.Favicon" Version="0.1.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.8.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.8.1-rc1" />
     <PackageReference Include="Etch.OrchardCore.Gallery" Version="0.2.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.HostTheme" Version="0.1.1-rc1" />
     <PackageReference Include="Etch.OrchardCore.InjectScripts" Version="0.2.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.News" Version="0.1.3-rc1" />
-    <PackageReference Include="Etch.OrchardCore.SEO" Version="0.5.4-rc1" />
+    <PackageReference Include="Etch.OrchardCore.SEO" Version="0.5.5-rc1" />
     <PackageReference Include="Etch.OrchardCore.Widgets" Version="0.7.0-rc1" />
     <PackageReference Include="Etch.OrchardCore.Workflows" Version="0.2.0-rc1" />
     <PackageReference Include="OpenIddict.Mvc" Version="2.0.1" />

--- a/Etch.OrchardCore.SiteBoilerplate.nuspec
+++ b/Etch.OrchardCore.SiteBoilerplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Etch.OrchardCore.SiteBoilerplate</id>
-    <version>0.4.4</version>
+    <version>0.4.5</version>
     <title>Etch Orchard Core Site Boilerplate</title>
     <description>
       Boilerplate site that is our starting point for building OrchardCore sites.


### PR DESCRIPTION
- Upgrade terraform to v0.12 (fixes #46)
- Update project build script to our regular format
    - Include npm package caching
    - Include step for defining node version
    - Include terraform files in build artifact
    - Change archive file containing `dotnet publish` artifact is always named the same instead of containing a build number
- Update key for  CDN url setting for Orchard Core (fixes #47)