### PR TITLE
Upgrade RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
-dist: xenial
-dotnet: 3.0
+dist: bionic
+dotnet: 3.1
 
 env:
   global:

--- a/Content/README.md
+++ b/Content/README.md
@@ -10,7 +10,7 @@ Orchard Core runs on the .NET Core. Download the latest version from [https://ww
 
 ## Orchard Core Reference
 
-This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
+This project is referencing the RC2 build of Orchard Core ([`1.0.0-rc2-13450`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc2-13450)).
 
 ## Running Locally
 
@@ -23,3 +23,7 @@ Run the command shown below and then navigate to `https://localhost:5001` in you
 ### Visual Studio
 
 Open the solution in Visual Studio and run the `Etch.OrchardCore.SiteBoilerplate` project. This will open your default browser and you'll be presented with the Orchard setup page.
+
+## Notes
+
+This project was created using `v0.4.7` of [Etch.OrchardCore.SiteBoilerplate](https://github.com/EtchUK/Etch.OrchardCore.SiteBoilerplate) template.

--- a/Content/README.md
+++ b/Content/README.md
@@ -26,4 +26,4 @@ Open the solution in Visual Studio and run the `Etch.OrchardCore.SiteBoilerplate
 
 ## Notes
 
-This project was created using `v0.4.7` of [Etch.OrchardCore.SiteBoilerplate](https://github.com/EtchUK/Etch.OrchardCore.SiteBoilerplate) template.
+This project was created using `v0.5.0` of [Etch.OrchardCore.SiteBoilerplate](https://github.com/EtchUK/Etch.OrchardCore.SiteBoilerplate) template.

--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <PreserveCompilationReferences>true</PreserveCompilationReferences>
@@ -9,26 +9,27 @@
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
+    <Folder Include="Localization\" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Etch.OrchardCore.AdminTheme" Version="0.2.1-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Blocks" Version="0.2.1-rc1" />
-    <PackageReference Include="Etch.OrchardCore.ContentPermissions" Version="0.2.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.ContextualEdit" Version="0.2.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.DefaultTheme" Version="0.5.1-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Favicon" Version="0.1.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.8.1-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Gallery" Version="0.2.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.HostTheme" Version="0.1.1-rc1" />
-    <PackageReference Include="Etch.OrchardCore.InjectScripts" Version="0.2.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.News" Version="0.1.3-rc1" />
-    <PackageReference Include="Etch.OrchardCore.SEO" Version="0.5.5-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Widgets" Version="0.7.0-rc1" />
-    <PackageReference Include="Etch.OrchardCore.Workflows" Version="0.2.0-rc1" />
+    <PackageReference Include="Etch.OrchardCore.AdminTheme" Version="0.3.1-rc2" />
+    <PackageReference Include="Etch.OrchardCore.Blocks" Version="0.3.0-rc2" />
+    <PackageReference Include="Etch.OrchardCore.ContentPermissions" Version="0.3.1-rc2" />
+    <PackageReference Include="Etch.OrchardCore.ContextualEdit" Version="0.3.1-rc2" />
+    <PackageReference Include="Etch.OrchardCore.DefaultTheme" Version="0.6.0-rc2" />
+    <PackageReference Include="Etch.OrchardCore.Favicon" Version="0.2.0-rc2" />
+    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.9.2-rc2" />
+    <PackageReference Include="Etch.OrchardCore.Gallery" Version="0.3.2-rc2" />
+    <PackageReference Include="Etch.OrchardCore.HostTheme" Version="0.2.2-rc2" />
+    <PackageReference Include="Etch.OrchardCore.InjectScripts" Version="0.3.0-rc2" />
+    <PackageReference Include="Etch.OrchardCore.News" Version="0.2.0-rc2" />
+    <PackageReference Include="Etch.OrchardCore.SEO" Version="0.6.1-rc2" />
+    <PackageReference Include="Etch.OrchardCore.Widgets" Version="0.10.0-rc2" />
+    <PackageReference Include="Etch.OrchardCore.Workflows" Version="0.3.0-rc2" />
     <PackageReference Include="OpenIddict.Mvc" Version="2.0.1" />
-    <PackageReference Include="OrchardCore.Application.Cms.Core.Targets" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Logging.NLog" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Application.Cms.Core.Targets" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Logging.NLog" Version="1.0.0-rc2-13450" />
   </ItemGroup>
 
 </Project>

--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/NLog.config
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/NLog.config
@@ -5,20 +5,28 @@
       internalLogLevel="Warn"
       internalLogFile="App_Data/logs/internal-nlog.txt">
 
-    <extensions>
-        <add assembly="NLog.Web.AspNetCore"/>
-        <add assembly="OrchardCore.Logging.NLog"/>
-    </extensions>
+  <extensions>
+    <add assembly="NLog.Web.AspNetCore"/>
+    <add assembly="OrchardCore.Logging.NLog"/>
+  </extensions>
 
-    <!-- define various log targets -->
-    <targets>
-        <!-- write logs to file -->
-        <target xsi:type="File" name="allfile" fileName="${var:configDir}/App_Data/logs/orchard-log-${shortdate}.log"
-                    layout="${longdate}|${orchard-tenant-name}|${aspnet-traceidentifier}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|${message} ${exception:format=ToString,StackTrace}" />
-    </targets>
+  <targets>
+    <!-- file target -->
+    <target xsi:type="File" name="file"
+            fileName="${var:configDir}/App_Data/logs/orchard-log-${shortdate}.log"
+            layout="${longdate}|${orchard-tenant-name}|${aspnet-traceidentifier}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|${message} ${exception:format=ToString,StackTrace}"
+        />
 
-    <rules>
-        <!--All logs-->
-        <logger name="*" minlevel="Error" writeTo="allfile" />
-    </rules>
+    <!-- console target -->
+    <target xsi:type="Console" name="console" />
+
+  </targets>
+
+  <rules>
+    <!-- all warnings and above go to the file target -->
+    <logger name="*" minlevel="Warn" writeTo="file" />
+
+    <!-- the hosting lifetime events go to the console -->
+    <logger name="Microsoft.Hosting.Lifetime" minlevel="Info" writeTo="console" />
+  </rules>
 </nlog>

--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/appsettings.json
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/appsettings.json
@@ -1,6 +1,6 @@
 {
   "OrchardCore": {
-    "OrchardCore.Media": {
+    "OrchardCore_Media": {
       "AllowedFileExtensions": [
         ".csv",
         ".doc",

--- a/Etch.OrchardCore.SiteBoilerplate.nuspec
+++ b/Etch.OrchardCore.SiteBoilerplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Etch.OrchardCore.SiteBoilerplate</id>
-    <version>0.4.7</version>
+    <version>0.5.0</version>
     <title>Etch Orchard Core Site Boilerplate</title>
     <description>
       Boilerplate site that is our starting point for building OrchardCore sites.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Site boilerplate is our starting point for building Orchard Core sites.
 
 [![Build Status](https://secure.travis-ci.org/EtchUK/Etch.OrchardCore.SiteBoilerplate.png?branch=master)](http://travis-ci.org/EtchUK/Etch.OrchardCore.SiteBoilerplate) [![NuGet](https://img.shields.io/nuget/v/Etch.OrchardCore.SiteBoilerplate.svg)](https://www.nuget.org/packages/Etch.OrchardCore.SiteBoilerplate)
 
+## Orchard Core Reference
+
+This template is referencing the RC2 build of Orchard Core ([`1.0.0-rc2-13450`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc2-13450)).
+
 ## Prerequisities
 
 ### [.NET Core](https://docs.microsoft.com/en-us/dotnet/core/)


### PR DESCRIPTION
Upgrade boilerplate to RC2.

- Update project target framework to `3.1`
- Update Orchard Core reference to RC2
- Update `appSettings.json` to use new syntax that enables support for running on Linux
- Update docs to indicate which version of Orchard Core is targetted
- Add section to project README to indicate what version of the template was used to generate project
- Update `NLog.config` to match project templates within Orchard Core source