### PR TITLE
Switch to use native cache task in pipeline

### DIFF
--- a/Content/azure-pipeline.yml
+++ b/Content/azure-pipeline.yml
@@ -11,6 +11,7 @@ trigger:
 
 variables:
   buildConfiguration: "Release"
+  NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
 
 stages:
   - stage: build
@@ -22,12 +23,13 @@ stages:
         pool:
           vmImage: "windows-latest"
         steps:
-          - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-            displayName: "Restore artifact based on: **/package-lock.json"
+          - task: Cache@2
+            displayName: Cache NuGet packages
             inputs:
-              keyfile: "**/package-lock.json"
-              targetfolder: "**/node_modules,**/node_modules/**/node_modules"
-              vstsFeed: "43c91cfb-ae45-4e8c-a2f5-8a34df9e3b8a"
+              key: 'nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/src/Etch.OrchardCore.SiteBoilerplate/packages.lock.json'
+              restoreKeys: |
+                nuget | "$(Agent.OS)"
+              path: $(NUGET_PACKAGES)
 
           - task: UseNode@1
             inputs:

--- a/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
+++ b/Content/src/Etch.OrchardCore.SiteBoilerplate/Etch.OrchardCore.SiteBoilerplate.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <PreserveCompilationReferences>true</PreserveCompilationReferences>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Change caching task to cache the NuGet packages instead of the npm packages, which wasn't working anyways.

Resolves #63.