### PR TITLE
Ignore wwwroot folder during deployment

### DIFF
--- a/Content/azure-pipeline.yml
+++ b/Content/azure-pipeline.yml
@@ -99,6 +99,7 @@ stages:
                     packageForLinux: "$(Pipeline.Workspace)/drop/Etch.OrchardCore.SiteBoilerplate.zip"
                     enableCustomDeployment: true
                     RemoveAdditionalFilesFlag: true
+                    AdditionalArguments: '-skip:objectName=dirPath,absolutePath=wwwroot'
 
   - stage: prod_deploy
     dependsOn: build
@@ -124,3 +125,4 @@ stages:
                     packageForLinux: "$(Pipeline.Workspace)/drop/Etch.OrchardCore.SiteBoilerplate.zip"
                     enableCustomDeployment: true
                     RemoveAdditionalFilesFlag: true
+                    AdditionalArguments: '-skip:objectName=dirPath,absolutePath=wwwroot'


### PR DESCRIPTION
wwwroot folder contains a cache of resized images.

Fixes #70.