### PR TITLE
Ignore terraform dependency lock file

### DIFF
--- a/Content/deployment/terraform/.gitignore
+++ b/Content/deployment/terraform/.gitignore
@@ -9,3 +9,6 @@
 
 # State files
 *.tfstate*
+
+# Dependency lock file
+.terraform.lock.hcl


### PR DESCRIPTION
Terraform introduced a dependency lock file in version 0.14 that shouldn't be included in the source files.